### PR TITLE
bugfix related to numpy DeprecationWarning of 1d array passing error …

### DIFF
--- a/fastdtw/fastdtw.py
+++ b/fastdtw/fastdtw.py
@@ -138,7 +138,7 @@ def __dtw(x, y, window, dist):
     D = defaultdict(lambda: (float('inf'),))
     D[0, 0] = (0, 0, 0)
     for i, j in window:
-        dt = dist(x[i-1], y[j-1])
+        dt = np.sum(dist(x[i-1].reshape(-1, 1), y[j-1].reshape(-1, 1)))
         D[i, j] = min((D[i-1, j][0]+dt, i-1, j), (D[i, j-1][0]+dt, i, j-1),
                       (D[i-1, j-1][0]+dt, i-1, j-1), key=lambda a: a[0])
     path = []


### PR DESCRIPTION
…will raise ValueError in numpy 0.19

Line 141 of fastdtw.py raises DeprecationWarning that Passing 1d arrays as data is deprecated in 0.17 and will raise ValueError in 0.19 because dist(...) returns numpy.array of size (1, 1).
The update just changed the line to suppress the warning/error.