### PR TITLE
replace np.float with np.floating to mitigate FutureWarning

### DIFF
--- a/fastdtw/_fastdtw.pyx
+++ b/fastdtw/_fastdtw.pyx
@@ -255,8 +255,8 @@ cdef double __dtw(x, y, vector[WindowElement] &window, dist,
     cdef double pnorm = -1.0 if not isinstance(dist, numbers.Number) else dist
     if ((dist is None or pnorm > 0) and
         (isinstance(x, np.ndarray) and isinstance(y, np.ndarray) and
-         np.issubdtype(x.dtype, np.float) and
-         np.issubdtype(y.dtype, np.float))):
+         np.issubdtype(x.dtype, np.floating) and
+         np.issubdtype(y.dtype, np.floating))):
 
         if x.ndim == 1:
             if dist is None:


### PR DESCRIPTION
Call to `np.issubdtype` [here](https://github.com/slaypni/fastdtw/blob/master/fastdtw/_fastdtw.pyx#L258-L259), with `np.float` instead of `np.floating` raises the following `FutureWarning`:
> FutureWarning: Conversion of the second argument of issubdtype from `float` to `np.floating` is deprecated. In future, it will be treated as `np.float64 == np.dtype(float).type`.
---

python version: 3.6.4
numpy version: 1.14.2

---
Example:
```
Python 3.6.4 (default, Jan  5 2018, 02:35:40) 
[GCC 7.2.1 20171224] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import numpy as np
>>> from scipy.spatial.distance import euclidean
>>> 
>>> from fastdtw import fastdtw
>>> 
>>> x = np.array([[1,1], [2,2], [3,3], [4,4], [5,5]])
>>> y = np.array([[2,2], [3,3], [4,4]])
>>> distance, path = fastdtw(x, y)
__main__:1: FutureWarning: Conversion of the second argument of issubdtype from `float` to `np.floating` is deprecated. In future, it will be treated as `np.float64 == np.dtype(float).type`.
>>> print(distance)
4.0
>>> 
```