### PR TITLE
Fix single-dimensional inputs in the pure python impl

### DIFF
--- a/fastdtw/fastdtw.py
+++ b/fastdtw/fastdtw.py
@@ -58,7 +58,7 @@ def __difference(a, b):
 
 
 def __norm(p):
-    return lambda a, b: np.linalg.norm(a - b, p)
+    return lambda a, b: np.linalg.norm(np.atleast_1d(a) - np.atleast_1d(b), p)
 
 
 def __fastdtw(x, y, radius, dist):


### PR DESCRIPTION
Otherwise, I get the following error:

```
  File "/usr/local/lib/python3.7/dist-packages/fastdtw/fastdtw.py", line 53, in fastdtw
    return __fastdtw(x, y, radius, dist)
  File "/usr/local/lib/python3.7/dist-packages/fastdtw/fastdtw.py", line 73, in __fastdtw
    __fastdtw(x_shrinked, y_shrinked, radius=radius, dist=dist)
  File "/usr/local/lib/python3.7/dist-packages/fastdtw/fastdtw.py", line 73, in __fastdtw
    __fastdtw(x_shrinked, y_shrinked, radius=radius, dist=dist)
  File "/usr/local/lib/python3.7/dist-packages/fastdtw/fastdtw.py", line 73, in __fastdtw
    __fastdtw(x_shrinked, y_shrinked, radius=radius, dist=dist)
  [Previous line repeated 4 more times]
  File "/usr/local/lib/python3.7/dist-packages/fastdtw/fastdtw.py", line 68, in __fastdtw
    return dtw(x, y, dist=dist)
  File "/usr/local/lib/python3.7/dist-packages/fastdtw/fastdtw.py", line 130, in dtw
    return __dtw(x, y, None, dist)
  File "/usr/local/lib/python3.7/dist-packages/fastdtw/fastdtw.py", line 141, in __dtw
    dt = dist(x[i-1], y[j-1])
  File "/usr/local/lib/python3.7/dist-packages/fastdtw/fastdtw.py", line 61, in <lambda>
    return lambda a, b: np.linalg.norm(a - b, p)
  File "/usr/local/lib/python3.7/dist-packages/numpy/linalg/linalg.py", line 2440, in norm
    raise ValueError("Improper number of dimensions to norm.")
```

on X and Y saved (numpy.save) to https://github.com/src-d/hercules/files/3025826/xy.zip