### PR TITLE
fix(cython): replace fallback import for INFINITY import in _fastdtw.pyx

### DIFF
--- a/fastdtw/_fastdtw.pyx
+++ b/fastdtw/_fastdtw.pyx
@@ -11,11 +11,7 @@ from libcpp.vector cimport vector
 
 import numpy as np
 
-try:
-  from libc.math cimport INFINITY
-except:
-  from numpy.math cimport INFINITY
-
+from libc.math cimport INFINITY
 
 cdef struct LowHigh:
     int low, high


### PR DESCRIPTION
This PR resolves a build error that occurs when compiling FastDTW from source.  
The Cython file `_fastdtw.pyx` contains a fallback `cimport` from `numpy.math`, which does not exist and breaks the build process.

- Replaced:
  ```cython
  try:
      from libc.math cimport INFINITY
  except:
      from numpy.math cimport INFINITY  # file doesn't exist
  ```
- With:
  ```cython
  from libc.math cimport INFINITY
  ```

This removes the broken fallback and ensures proper compilation of the C extension.

Without this fix, the build fails and FastDTW falls back to the pure Python implementation, which is up to **50× slower**.  
With the fix, the compiled `.so` extension is correctly built and used, unlocking FastDTW's intended performance.

NumPy seemingly removed `numpy.math.pxd` in version 2.0.0 as noted in their changelog:
https://github.com/numpy/numpy/blob/main/doc/changelog/2.0.0-changelog.rst

Related Issue

Closes #65

Let me know if any changes are needed — happy to adjust.